### PR TITLE
fix: race condition, feat: control by props 

### DIFF
--- a/cpp/RNSkSkottieView.h
+++ b/cpp/RNSkSkottieView.h
@@ -83,7 +83,7 @@ public:
   }
 
   bool isPaused() {
-    return _lastPauseTime > 0.0;
+    return _lastPauseTime > 0.0 || _startTime == -1.0;
   }
 
   void pause() {
@@ -212,7 +212,7 @@ public:
         setDrawingMode(RNSkDrawingMode::Continuous);
       } else if (prop.first == "pause") {
         if (std::static_pointer_cast<RNSkSkottieRenderer>(getRenderer())->isPaused()) {
-          return;
+            continue;
         }
 
         setDrawingMode(RNSkDrawingMode::Default);

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -83,7 +83,7 @@ function SkottieImperativeAPI({ source }: { source: AnimationObject }) {
 
 function SkottiePropsAPI({ source }: { source: AnimationObject }) {
   const [loop, setLoop] = React.useState(true);
-  const [autoPlay, setAutoPlay] = React.useState(true);
+  const [autoPlay, setAutoPlay] = React.useState(false);
   const [speed, setSpeed] = React.useState(1);
   const [_progress, setProgress] = React.useState(0);
 
@@ -108,15 +108,15 @@ function SkottiePropsAPI({ source }: { source: AnimationObject }) {
         }}
       />
       <Button
-        title="Loop"
+        title={`Toggle loop (its ${loop ? 'on' : 'off'})`}
         onPress={() => {
-          setLoop((loop) => !loop);
+          setLoop((p) => !p);
         }}
       />
       <Button
-        title="Speed"
+        title="Speed +1"
         onPress={() => {
-          setSpeed((speed) => speed + 1);
+          setSpeed((p) => p + 1);
         }}
       />
       <SkiaSkottieView


### PR DESCRIPTION
- Animation can now be controlled by just passing `autoPlay` prop
- Fixed a workaround we had to apply to prevent a race condition. Rather than doing the workaround, the native code was migrated from `callJsiMethod` to `setJsiProeprty` which we can always call.