### PR TITLE
fix(android): fix builds with RNSkia >= 1.x.x

### DIFF
--- a/package/android/CMakeLists.txt
+++ b/package/android/CMakeLists.txt
@@ -10,21 +10,9 @@ set(build_DIR ${CMAKE_SOURCE_DIR}/build)
 
 file(GLOB libfbjni_include_DIRS "${build_DIR}/fbjni-*-headers.jar/")
 
-# Consume shared libraries and headers from prefabs
+# We need to find packages since from RN 0.71 binaries are prebuilt
 find_package(fbjni REQUIRED CONFIG)
 find_package(ReactAndroid REQUIRED CONFIG)
-find_package(shopify_react-native-skia REQUIRED CONFIG)
-
-set(JSI_LIB ReactAndroid::jsi)
-message("-- JSI     : " ${JSI_LIB})
-set(FBJNI_LIBRARY fbjni::fbjni)
-message("-- FBJNI   : " ${FBJNI_LIBRARY})
-set(REACT_LIB ReactAndroid::react_nativemodule_core)
-message("-- REACT   : " ${REACT_LIB})
-set(TURBOMODULES_LIB "ReactAndroid::turbomodulejsijni")
-message("-- TURBO   : " ${TURBOMODULES_LIB})
-set(RNSKIA_LIB shopify_react-native-skia::rnskia)
-message("-- RNSKIA  : " ${RNSKIA_LIB})
 
 add_library(${PACKAGE_NAME}
         SHARED
@@ -51,53 +39,8 @@ include_directories(
         "${NODE_MODULES_DIR}/react-native/ReactCommon/react/nativemodule/core"
         "${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni"
 
-        # include skia headers
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/rnskia"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/skia/include/config/"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/skia/include/core/"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/skia/include/effects/"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/skia/include/utils/"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/skia/include/pathops/"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/skia/modules/"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/skia/modules/skparagraph/include/"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/skia/include/"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/skia"
-
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/api"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/jsi"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/rnskia"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/rnskia/values"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/rnskia/dom"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/rnskia/dom/base"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/rnskia/dom/nodes"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/rnskia/dom/props"
-        "${NODE_MODULES_DIR}/@shopify/react-native-skia/cpp/utils"
-
         ${libfbjni_include_DIRS}
 )
-
-# Import prebuilt skia skottie library
-set(SKIA_LIBS_PATH "${NODE_MODULES_DIR}/@shopify/react-native-skia/libs/android/${ANDROID_ABI}")
-
-set(SKIA_LIB "skia")
-add_library(skia STATIC IMPORTED)
-set_property(TARGET skia PROPERTY IMPORTED_LOCATION "${SKIA_LIBS_PATH}/libskia.a")
-
-set(SKIA_MODULE_SKOTTIE_LIB "skottie")
-add_library(skottie STATIC IMPORTED)
-set_property(TARGET skottie PROPERTY IMPORTED_LOCATION "${SKIA_LIBS_PATH}/libskottie.a")
-
-set(SKIA_SKSHAPER_LIB "skshaper")
-add_library(skshaper STATIC IMPORTED)
-set_property(TARGET skshaper PROPERTY IMPORTED_LOCATION "${SKIA_LIBS_PATH}/libskshaper.a")
-
-set(SKIA_MODULE_SKSG_LIB "sksg")
-add_library(sksg STATIC IMPORTED)
-set_property(TARGET sksg PROPERTY IMPORTED_LOCATION "${SKIA_LIBS_PATH}/libsksg.a")
-
-set(SKIA_MODULE_SKUNICODE_LIB "skunicode")
-add_library(skunicode STATIC IMPORTED)
-set_property(TARGET skunicode PROPERTY IMPORTED_LOCATION "${SKIA_LIBS_PATH}/libskunicode.a")
 
 # Android Log lib
 find_library(
@@ -108,19 +51,39 @@ find_library(
 # Link
 target_link_libraries(
         ${PACKAGE_NAME}
-        ${LOG_LIB}
-        ${FBJNI_LIBRARY}
-        ${REACT_LIB}
-        ${JSI_LIB}
-        ${TURBOMODULES_LIB}
-        ${SKIA_MODULE_SKOTTIE_LIB}
-        ${SKIA_SKSHAPER_LIB}
-        ${SKIA_MODULE_SKSG_LIB}
-        ${SKIA_MODULE_SKUNICODE_LIB}
-        ${SKIA_LIB}
-        ${RNSKIA_LIB}
+        ${LOG_LIB}                          # <-- Logcat logger
+        android                             # <-- Android JNI core
+        fbjni::fbjni                        # <-- fbjni
+        ReactAndroid::react_nativemodule_core # <-- RN: Native module core
+        ReactAndroid::jsi                   # <-- RN: JSI
+        ReactAndroid::reactnativejni        # <-- RN: React Native JNI bindings
+        ReactAndroid::runtimeexecutor       # <-- RN: Runtime executor
+        ReactAndroid::turbomodulejsijni     # <-- RN: TurboModule JSI JNI bindings
         -ljnigraphics
         -lGLESv2
         -lEGL
         -landroid
 )
+
+# 1. Link react-native-skia
+message("react-native-skottie: Linking react-native-skia...")
+find_package(shopify_react-native-skia REQUIRED CONFIG)
+target_link_libraries(
+        ${PACKAGE_NAME}
+        shopify_react-native-skia::rnskia
+)
+
+# 2. Add react-native-skia to path so it itself can find it's relative imports
+get_target_property(RN_SKIA_INCLUDE_DIR shopify_react-native-skia::rnskia INTERFACE_INCLUDE_DIRECTORIES)
+message("react-native-skottie: react-native-skia include directory: ${RN_SKIA_INCLUDE_DIR}")
+include_directories("${RN_SKIA_INCLUDE_DIR}/react-native-skia")
+
+# 3. Link skia itself
+set(RN_SKIA_DIR "${NODE_MODULES_DIR}/@shopify/react-native-skia")
+message("react-native-skottie: react-native-skia directory: ${RN_SKIA_DIR}")
+file(GLOB skiaLibraries "${RN_SKIA_DIR}/libs/android/${ANDROID_ABI}/*.a")
+foreach(skiaLibrary ${skiaLibraries})
+  message("react-native-skottie: Linking ${skiaLibrary}...")
+  target_link_libraries(${PACKAGE_NAME} "${skiaLibrary}")
+endforeach()
+

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -116,12 +116,20 @@ android {
     excludes = [
       "META-INF",
       "META-INF/**",
-//      "**/libc++_shared.so",
-//      "**/libfbjni.so",
-      "**/librnskia.so",
+      "**/libc++_shared.so",
+      "**/libfbjni.so",
       "**/libjsi.so",
-      "**/libreact_nativemodule_core.so",
+      "**/libfolly_json.so",
+      "**/libfolly_runtime.so",
+      "**/libglog.so",
+      "**/libhermes.so",
+      "**/libhermes-executor-debug.so",
+      "**/libhermes_executor.so",
+      "**/libreactnativejni.so",
       "**/libturbomodulejsijni.so",
+      "**/libreact_nativemodule_core.so",
+      "**/libjscexecutor.so",
+      "**/libruntimeexecutor.so"
     ]
     sourceSets {
       main {

--- a/package/android/cpp/jni/include/JniSkiaSkottieView.h
+++ b/package/android/cpp/jni/include/JniSkiaSkottieView.h
@@ -7,14 +7,15 @@
 #include <jni.h>
 #include <jsi/jsi.h>
 
-#include <JniSkiaBaseView.h>
-#include <JniSkiaManager.h>
-#include <RNSkAndroidView.h>
-#include <RNSkSkottieView.h>
+#include <react-native-skia/JniSkiaBaseView.h>
+#include <react-native-skia/JniSkiaManager.h>
+#include <react-native-skia/RNSkAndroidView.h>
 
 #include <android/native_window.h>
 #include <android/native_window_jni.h>
 #include <fbjni/detail/Hybrid.h>
+
+#include "RNSkSkottieView.h"
 
 namespace RNSkia {
 namespace jsi = facebook::jsi;

--- a/package/cpp/JsiSkSkottie.h
+++ b/package/cpp/JsiSkSkottie.h
@@ -2,8 +2,8 @@
 
 #include <jsi/jsi.h>
 
-#include <JsiSkCanvas.h>
-#include <JsiSkHostObjects.h>
+#include <react-native-skia/JsiSkCanvas.h>
+#include <react-native-skia/JsiSkHostObjects.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"

--- a/package/cpp/RNSkSkottieView.h
+++ b/package/cpp/RNSkSkottieView.h
@@ -10,20 +10,20 @@
 
 #include <jsi/jsi.h>
 
-#include "JsiValueWrapper.h"
-#include "RNSkView.h"
+#include <react-native-skia/JsiValueWrapper.h>
+#include <react-native-skia/RNSkView.h>
+#include <react-native-skia/JsiSkPicture.h>
+#include <react-native-skia/RNSkInfoParameter.h>
+#include <react-native-skia/RNSkLog.h>
+#include <react-native-skia/RNSkPlatformContext.h>
 
-#include "JsiSkPicture.h"
-#include "RNSkInfoParameter.h"
-#include "RNSkLog.h"
-#include "RNSkPlatformContext.h"
 #include "RNSkTime.h"
 #include "RNSkTimingInfo.h"
+#include "JsiSkSkottie.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
 
-#include "JsiSkSkottie.h"
 #include <include/core/SkBBHFactory.h>
 #include <include/core/SkCanvas.h>
 #include <include/core/SkPictureRecorder.h>

--- a/package/cpp/RNSkSkottieView.h
+++ b/package/cpp/RNSkSkottieView.h
@@ -24,9 +24,9 @@
 #pragma clang diagnostic ignored "-Wdocumentation"
 
 #include "JsiSkSkottie.h"
-#include "SkBBHFactory.h"
-#include "SkCanvas.h"
-#include "SkPictureRecorder.h"
+#include <include/core/SkBBHFactory.h>
+#include <include/core/SkCanvas.h>
+#include <include/core/SkPictureRecorder.h>
 #include <algorithm>
 #include <modules/skottie/include/Skottie.h>
 #include <vector>

--- a/package/cpp/RNSkSkottieView.h
+++ b/package/cpp/RNSkSkottieView.h
@@ -10,24 +10,24 @@
 
 #include <jsi/jsi.h>
 
-#include <react-native-skia/JsiValueWrapper.h>
-#include <react-native-skia/RNSkView.h>
 #include <react-native-skia/JsiSkPicture.h>
+#include <react-native-skia/JsiValueWrapper.h>
 #include <react-native-skia/RNSkInfoParameter.h>
 #include <react-native-skia/RNSkLog.h>
 #include <react-native-skia/RNSkPlatformContext.h>
+#include <react-native-skia/RNSkView.h>
 
+#include "JsiSkSkottie.h"
 #include "RNSkTime.h"
 #include "RNSkTimingInfo.h"
-#include "JsiSkSkottie.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
 
+#include <algorithm>
 #include <include/core/SkBBHFactory.h>
 #include <include/core/SkCanvas.h>
 #include <include/core/SkPictureRecorder.h>
-#include <algorithm>
 #include <modules/skottie/include/Skottie.h>
 #include <vector>
 

--- a/package/cpp/react-native-skia-skottie.h
+++ b/package/cpp/react-native-skia-skottie.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <RNSkPlatformContext.h>
+#include <react-native-skia/RNSkPlatformContext.h>
 #include <jsi/jsi.h>
 
 namespace RNSkia {

--- a/package/cpp/react-native-skia-skottie.h
+++ b/package/cpp/react-native-skia-skottie.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <react-native-skia/RNSkPlatformContext.h>
 #include <jsi/jsi.h>
+#include <react-native-skia/RNSkPlatformContext.h>
 
 namespace RNSkia {
 using namespace facebook;

--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -319,7 +319,7 @@ PODS:
   - React-jsinspector (0.72.7)
   - React-logger (0.72.7):
     - glog
-  - react-native-skia (0.1.234):
+  - react-native-skia (1.2.3):
     - RCT-Folly (= 2021.07.22.00)
     - React
     - React-callinvoker
@@ -617,8 +617,8 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c49502e5d02112247ee4526bc3ccfc891ae3eb9b
   React-jsinspector: 8baadae51f01d867c3921213a25ab78ab4fbcd91
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
-  react-native-skia: 60202ab85d2ea2f90f9e3d70f4dcb00fd589e72e
-  react-native-skia-skottie: e36c5638dfa4c142566e52a18f802803424e4d84
+  react-native-skia: d368ae81d61c0253df36106ea76324b5a5519ddc
+  react-native-skia-skottie: a1b7c13100050b737cf36edc41e91b4c2ccdc02e
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a
   React-perflogger: 31ea61077185eb1428baf60c0db6e2886f141a5a
   React-RCTActionSheet: 392090a3abc8992eb269ef0eaa561750588fc39d
@@ -643,4 +643,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: c7f52fd444eff4e4c78e5f161bdab7d531608ee1
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.12.1

--- a/package/example/package.json
+++ b/package/example/package.json
@@ -10,7 +10,7 @@
     "typescript": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/react-native-skia": "^0.1.234",
+    "@shopify/react-native-skia": "^1.2.3",
     "lottie-react-native": "^6.4.1",
     "react": "18.2.0",
     "react-native": "0.72.7",

--- a/package/example/yarn.lock
+++ b/package/example/yarn.lock
@@ -1759,13 +1759,13 @@
     invariant "^2.2.4"
     nullthrows "^1.1.1"
 
-"@shopify/react-native-skia@^0.1.234":
-  version "0.1.234"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.234.tgz#cf3d43935a2f5c9fd5186017e285194897cf0fe7"
-  integrity sha512-PfXXqpjyjQkdgOcy3MU6KqJdu2O9yfh4cZ8Sg/mFNP2kgkO4BUhIi3tXfXZAdS06JxvT25/A1LOdvuQuEPg7xw==
+"@shopify/react-native-skia@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-1.2.3.tgz#d87efd01c362b69f62375ce950c30e453586d6f9"
+  integrity sha512-gyUD/HGsMyZ+YAoWxVh24HYN5juwC/dZWINL/0sKP7Ttee/0igCRxWPneH1BbVH28dhyf+tvksQNUwpMM3VWbg==
   dependencies:
     canvaskit-wasm "0.39.1"
-    react-reconciler "^0.27.0"
+    react-reconciler "0.27.0"
 
 "@sideway/address@^4.1.3":
   version "4.1.4"
@@ -3935,7 +3935,7 @@ react-native@0.72.7:
     ws "^6.2.2"
     yargs "^17.6.2"
 
-react-reconciler@^0.27.0:
+react-reconciler@0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.27.0.tgz#360124fdf2d76447c7491ee5f0e04503ed9acf5b"
   integrity sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==

--- a/package/package.json
+++ b/package/package.json
@@ -75,10 +75,10 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@shopify/react-native-skia": "^0.1.230"
+    "@shopify/react-native-skia": "^1.2.3"
   },
   "peerDependencies": {
-    "@shopify/react-native-skia": ">= 0.1.228",
+    "@shopify/react-native-skia": ">=1.0.0",
     "react": "*",
     "react-native": "*",
     "react-native-reanimated": ">=2.0.0"

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -2226,13 +2226,13 @@
     conventional-recommended-bump "^6.1.0"
     semver "7.3.8"
 
-"@shopify/react-native-skia@^0.1.230":
-  version "0.1.234"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.234.tgz#cf3d43935a2f5c9fd5186017e285194897cf0fe7"
-  integrity sha512-PfXXqpjyjQkdgOcy3MU6KqJdu2O9yfh4cZ8Sg/mFNP2kgkO4BUhIi3tXfXZAdS06JxvT25/A1LOdvuQuEPg7xw==
+"@shopify/react-native-skia@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-1.2.3.tgz#d87efd01c362b69f62375ce950c30e453586d6f9"
+  integrity sha512-gyUD/HGsMyZ+YAoWxVh24HYN5juwC/dZWINL/0sKP7Ttee/0igCRxWPneH1BbVH28dhyf+tvksQNUwpMM3VWbg==
   dependencies:
     canvaskit-wasm "0.39.1"
-    react-reconciler "^0.27.0"
+    react-reconciler "0.27.0"
 
 "@sideway/address@^4.1.3":
   version "4.1.4"
@@ -7864,7 +7864,7 @@ react-native@0.72.7:
     ws "^6.2.2"
     yargs "^17.6.2"
 
-react-reconciler@^0.27.0:
+react-reconciler@0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.27.0.tgz#360124fdf2d76447c7491ee5f0e04503ed9acf5b"
   integrity sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==


### PR DESCRIPTION
This PR addresses build issues that were especially reported on android when trying to use the latest RNSkia version.
From this PR onwards, we will only maintain support for RNSkia >= 1.x.x

Fixes:

- https://github.com/margelo/react-native-skottie/issues/28#issuecomment-2001815377