### PR TITLE
fix(ios): fix ios not building when using use_frameworks with static linkage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,13 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      # Use java 17:
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "adopt"
+          java-version: "17"
+
       - name: Build Android
         run: cd example && npx react-native build-android --mode=debug
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,14 +107,15 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      # Use java 17:
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "adopt"
+          java-version: "17"
+
       - name: Build Android
         run: cd example && npx react-native build-android --mode=release
-
-        # - name: Setup Java
-        # uses: actions/setup-java@v3
-        # with:
-        #   distribution: "oracle"
-        #   java-version: "17"
 
   ios-debug:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,5 +142,5 @@ jobs:
         working-directory: ./package/example/ios
 
       - name: Build iOS
-        run: yes | npx react-native build-ios --configuration Debug
+        run: yes | npx react-native build-ios --mode Debug
         working-directory: ./package/example

--- a/package/android/cpp/jni/include/JniSkiaSkottieView.h
+++ b/package/android/cpp/jni/include/JniSkiaSkottieView.h
@@ -7,9 +7,9 @@
 #include <jni.h>
 #include <jsi/jsi.h>
 
-#include <react-native-skia/JniSkiaBaseView.h>
-#include <react-native-skia/JniSkiaManager.h>
-#include <react-native-skia/RNSkAndroidView.h>
+#include "JniSkiaBaseView.h"
+#include "JniSkiaManager.h"
+#include "RNSkAndroidView.h"
 
 #include <android/native_window.h>
 #include <android/native_window_jni.h>

--- a/package/cpp/JsiSkSkottie.h
+++ b/package/cpp/JsiSkSkottie.h
@@ -2,8 +2,8 @@
 
 #include <jsi/jsi.h>
 
-#include <react-native-skia/JsiSkCanvas.h>
-#include <react-native-skia/JsiSkHostObjects.h>
+#include "JsiSkCanvas.h"
+#include "JsiSkHostObjects.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"

--- a/package/cpp/RNSkSkottieView.h
+++ b/package/cpp/RNSkSkottieView.h
@@ -10,12 +10,12 @@
 
 #include <jsi/jsi.h>
 
-#include <react-native-skia/JsiSkPicture.h>
-#include <react-native-skia/JsiValueWrapper.h>
-#include <react-native-skia/RNSkInfoParameter.h>
-#include <react-native-skia/RNSkLog.h>
-#include <react-native-skia/RNSkPlatformContext.h>
-#include <react-native-skia/RNSkView.h>
+#include "JsiSkPicture.h"
+#include "JsiValueWrapper.h"
+#include "RNSkInfoParameter.h"
+#include "RNSkLog.h"
+#include "RNSkPlatformContext.h"
+#include "RNSkView.h"
 
 #include "JsiSkSkottie.h"
 #include "RNSkTime.h"

--- a/package/cpp/react-native-skia-skottie.h
+++ b/package/cpp/react-native-skia-skottie.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <jsi/jsi.h>
 #include "RNSkPlatformContext.h"
+#include <jsi/jsi.h>
 
 namespace RNSkia {
 using namespace facebook;

--- a/package/cpp/react-native-skia-skottie.h
+++ b/package/cpp/react-native-skia-skottie.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <jsi/jsi.h>
-#include <react-native-skia/RNSkPlatformContext.h>
+#include "RNSkPlatformContext.h"
 
 namespace RNSkia {
 using namespace facebook;

--- a/package/example/ios/SkiaSkottieExample.xcodeproj/project.pbxproj
+++ b/package/example/ios/SkiaSkottieExample.xcodeproj/project.pbxproj
@@ -11,10 +11,10 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		3550FEF275B532601FA3A2D1 /* libPods-SkiaSkottieExample-SkiaSkottieExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B6ADDB42D15ED0B5396A797 /* libPods-SkiaSkottieExample-SkiaSkottieExampleTests.a */; };
+		636BDB20ACBD5B04CE2F4236 /* libPods-SkiaSkottieExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D8E7A6E38922BDCF9DF66424 /* libPods-SkiaSkottieExample.a */; };
 		6AF902BEC9C0D526D0F0FEAC /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 8597BB3647B41582B7EE2B95 /* PrivacyInfo.xcprivacy */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		D59FB581CA39B0F9DD790ADC /* libPods-SkiaSkottieExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 299163CFAF3C3D8FB5A0D822 /* libPods-SkiaSkottieExample.a */; };
+		9CE03E7C5464CBF413F4281F /* libPods-SkiaSkottieExample-SkiaSkottieExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A649F30FE1B90109D355CCC /* libPods-SkiaSkottieExample-SkiaSkottieExampleTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,12 +38,12 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = SkiaSkottieExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = SkiaSkottieExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = SkiaSkottieExample/main.m; sourceTree = "<group>"; };
-		1B6ADDB42D15ED0B5396A797 /* libPods-SkiaSkottieExample-SkiaSkottieExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SkiaSkottieExample-SkiaSkottieExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		299163CFAF3C3D8FB5A0D822 /* libPods-SkiaSkottieExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SkiaSkottieExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4A649F30FE1B90109D355CCC /* libPods-SkiaSkottieExample-SkiaSkottieExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SkiaSkottieExample-SkiaSkottieExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FC810A6FF54600A42A171F2 /* Pods-SkiaSkottieExample-SkiaSkottieExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SkiaSkottieExample-SkiaSkottieExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-SkiaSkottieExample-SkiaSkottieExampleTests/Pods-SkiaSkottieExample-SkiaSkottieExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = SkiaSkottieExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8597BB3647B41582B7EE2B95 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = SkiaSkottieExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AB8D8DE14F8E215D2F0F440D /* Pods-SkiaSkottieExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SkiaSkottieExample.debug.xcconfig"; path = "Target Support Files/Pods-SkiaSkottieExample/Pods-SkiaSkottieExample.debug.xcconfig"; sourceTree = "<group>"; };
+		D8E7A6E38922BDCF9DF66424 /* libPods-SkiaSkottieExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SkiaSkottieExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DFB707D8DFDB91273C7F271D /* Pods-SkiaSkottieExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SkiaSkottieExample.release.xcconfig"; path = "Target Support Files/Pods-SkiaSkottieExample/Pods-SkiaSkottieExample.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -53,7 +53,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3550FEF275B532601FA3A2D1 /* libPods-SkiaSkottieExample-SkiaSkottieExampleTests.a in Frameworks */,
+				9CE03E7C5464CBF413F4281F /* libPods-SkiaSkottieExample-SkiaSkottieExampleTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -61,7 +61,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D59FB581CA39B0F9DD790ADC /* libPods-SkiaSkottieExample.a in Frameworks */,
+				636BDB20ACBD5B04CE2F4236 /* libPods-SkiaSkottieExample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -103,8 +103,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				299163CFAF3C3D8FB5A0D822 /* libPods-SkiaSkottieExample.a */,
-				1B6ADDB42D15ED0B5396A797 /* libPods-SkiaSkottieExample-SkiaSkottieExampleTests.a */,
+				D8E7A6E38922BDCF9DF66424 /* libPods-SkiaSkottieExample.a */,
+				4A649F30FE1B90109D355CCC /* libPods-SkiaSkottieExample-SkiaSkottieExampleTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -587,6 +587,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD = "";
 				LDPLUSPLUS = "";
@@ -663,6 +674,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD = "";
 				LDPLUSPLUS = "";

--- a/package/example/ios/SkiaSkottieExample/PrivacyInfo.xcprivacy
+++ b/package/example/ios/SkiaSkottieExample/PrivacyInfo.xcprivacy
@@ -19,6 +19,8 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>CA92.1</string>
+				<string>1C8F.1</string>
+				<string>C56D.1</string>
 			</array>
 		</dict>
 		<dict>

--- a/package/example/package.json
+++ b/package/example/package.json
@@ -20,9 +20,9 @@
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
+    "@react-native/babel-preset": "0.74.83",
     "@react-native/metro-config": "0.74.83",
     "babel-plugin-module-resolver": "^4.1.0",
-    "@react-native/babel-preset": "0.74.83",
     "pod-install": "^0.1.39"
   },
   "engines": {

--- a/package/ios/SkiaSkottieViewManager.mm
+++ b/package/ios/SkiaSkottieViewManager.mm
@@ -1,13 +1,13 @@
 #include "SkiaSkottieViewManager.h"
 #include <React/RCTBridge+Private.h>
 
-#include <RNSkIOSView.h>
-#include <RNSkPlatformContext.h>
-#include <RNSkSkottieView.h>
+#include "RNSkIOSView.h"
+#include "RNSkPlatformContext.h"
+#include "RNSkSkottieView.h"
 
 #include "SkiaManager.h"
 #include "SkiaUIView.h"
-#include <RNSkiaModule.h>
+#include "RNSkiaModule.h"
 
 @implementation SkiaSkottieViewManager
 

--- a/package/ios/SkiaSkottieViewManager.mm
+++ b/package/ios/SkiaSkottieViewManager.mm
@@ -5,9 +5,9 @@
 #include "RNSkPlatformContext.h"
 #include "RNSkSkottieView.h"
 
+#include "RNSkiaModule.h"
 #include "SkiaManager.h"
 #include "SkiaUIView.h"
-#include "RNSkiaModule.h"
 
 @implementation SkiaSkottieViewManager
 


### PR DESCRIPTION
For all RNSkia headers I had to use double quotes instead of angle brackets, as otherwise building on iOS with `use_frameworks! :linkage => :static` would fail.
With this configuration it builds for use_frameworks and without + android works as well.

Fixes: 

- #25 