### PR TITLE
doc: Update README.md about proguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,7 @@ We benchmarked react-native-skottie against [lottie-react-native](https://github
 yarn add react-native-skottie
 ```
 
-### Android
-
-#### Proguard
-
-If you're using Proguard, make sure to add the following rule at `proguard-rules.pro`
-
-```
-# for skia, if you haven't add it
--keep class com.shopify.reactnative.skia.** { *; }
-
-# for skottie
--keep class com.skiaskottie.** { *; }
-```
+For Android release build, check out the [note below.](#android)
 
 ### Usage
 
@@ -221,6 +209,20 @@ played. The API is of type `SkottieAPI` and provides the following methods:
 | Method name           | Description                                                          |
 |-----------------------|----------------------------------------------------------------------|
 | SkottieAPI.createFrom | Creates a Skottie instance from a source (string, json, file import) |
+
+### Android
+
+#### Proguard
+
+If you're using Proguard, make sure to add the following rule at `proguard-rules.pro`
+
+```
+# for skia, if you haven't add it
+-keep class com.shopify.reactnative.skia.** { *; }
+
+# for skottie
+-keep class com.skiaskottie.** { *; }
+```
 
 ### Community Discord
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We benchmarked react-native-skottie against [lottie-react-native](https://github
 yarn add react-native-skottie
 ```
 
-For Android release build, check out the [note below.](#android)
+For Android release build, check out the [note.](#android)
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We benchmarked react-native-skottie against [lottie-react-native](https://github
 yarn add react-native-skottie
 ```
 
-For Android release build, check out the [note.](#android)
+For Android release builds, check out the [note.](#android)
 
 ### Usage
 
@@ -214,7 +214,7 @@ played. The API is of type `SkottieAPI` and provides the following methods:
 
 #### Proguard
 
-If you're using Proguard, make sure to add the following rule at `proguard-rules.pro`
+If you're using Proguard, make sure to add the following rule in `proguard-rules.pro`
 
 ```
 # for skia, if you haven't add it

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ We benchmarked react-native-skottie against [lottie-react-native](https://github
 yarn add react-native-skottie
 ```
 
+### Android
+
+#### Proguard
+
+If you're using Proguard, make sure to add the following rule at `proguard-rules.pro`
+
+```
+# for skia, if you haven't add it
+-keep class com.shopify.reactnative.skia.** { *; }
+
+# for skottie
+-keep class com.skiaskottie.** { *; }
+```
+
 ### Usage
 
 ```tsx
@@ -207,20 +221,6 @@ played. The API is of type `SkottieAPI` and provides the following methods:
 | Method name           | Description                                                          |
 |-----------------------|----------------------------------------------------------------------|
 | SkottieAPI.createFrom | Creates a Skottie instance from a source (string, json, file import) |
-
-### Android
-
-#### Proguard
-
-If you're using Proguard, make sure to add the following rule at `proguard-rules.pro`
-
-```
-# for skia, if you haven't add it
--keep class com.shopify.reactnative.skia.** { *; }
-
-# for skottie
--keep class com.skiaskottie.** { *; }
-```
 
 ### Community Discord
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,20 @@ played. The API is of type `SkottieAPI` and provides the following methods:
 |-----------------------|----------------------------------------------------------------------|
 | SkottieAPI.createFrom | Creates a Skottie instance from a source (string, json, file import) |
 
+### Android
+
+#### Proguard
+
+If you're using Proguard, make sure to add the following rule at `proguard-rules.pro`
+
+```
+# for skia, if you haven't add it
+-keep class com.shopify.reactnative.skia.** { *; }
+
+# for skottie
+-keep class com.skiaskottie.** { *; }
+```
+
 ### Community Discord
 
 [Join the Margelo Community Discord](https://discord.gg/6CSHz2qAvA) to chat about react-native-skottie or other Margelo libraries.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ played. The API is of type `SkottieAPI` and provides the following methods:
 
 #### Proguard
 
-If you're using Proguard, make sure to add the following rule in `proguard-rules.pro`
+If you're using Proguard, make sure to add the following rule in `proguard-rules.pro`:
 
 ```
 # for skia, if you haven't add it


### PR DESCRIPTION
Building on Android with proguard enabled will require this rule to avoid crashing on release app.

Updating the readme to include this.

Relate to #44 and #42 