### PR TITLE
chore: fix SkottieViewRef play method types

### DIFF
--- a/package/src/SkottieView.tsx
+++ b/package/src/SkottieView.tsx
@@ -63,7 +63,7 @@ export type SkottieViewProps = NativeSkiaViewProps & {
 };
 
 export type SkottieViewRef = {
-  play: () => void;
+  play: (onAnimationFinish?: (isCancelled?: boolean) => void) => void;
   pause: () => void;
   reset: () => void;
 };


### PR DESCRIPTION
Reporting very minor typescript issue here. 

`play` method handles callback when animation ended. but missing in types. 

Checked callback works as I expected both Android and iOS. 

Thanks! 